### PR TITLE
fix dangling() return type from bool to int

### DIFF
--- a/src/LocARNA/pfold_params.hh
+++ b/src/LocARNA/pfold_params.hh
@@ -55,7 +55,7 @@ namespace LocARNA {
 	 *
 	 * @return value of dangling
 	 */
-	bool dangling() const {return dangling_;}
+	int dangling() const {return dangling_;}
 
     };
 


### PR DESCRIPTION
This should fix Clang compiler complains :)
