### PR TITLE
Adjust mlocarna-threaded test to changes in ViennaRNA Package 2.4.0

### DIFF
--- a/src/Tests/test_programs
+++ b/src/Tests/test_programs
@@ -136,7 +136,7 @@ mlocarna_calltest mlocarna-probabilistic \
 # check many threads, and local folding and max-diff-aln
 mlocarna_calltest mlocarna-threads \
          mlocarna $exdir/SECIS_15.fa  --threads 32 --alifold \
-         --plfold-span 50 --max-diff 10 --max-diff-aln $exdir/SECIS_15_ref.aln
+         --plfold-span 51 --max-diff 10 --max-diff-aln $exdir/SECIS_15_ref.aln
 
 # check anchor constraints from bed file
 mlocarna_calltest mlocarna-bed-anchors \


### PR DESCRIPTION
- Since ViennaRNA Package 2.4.0 maximum base pair span L for all sliding
  window structure prediction methods allows for base pairs (i,j) with
  (j - i + 1) <= L. However, equilibrium probability computations for
  base pairs and such used to constrain the base pair span as (j - i) <= L.
  Thus, to achieve the same result as with releases prior to v2.4.0
  the maximum base pair span needs to be increased by 1